### PR TITLE
Add unit test and CI pipeline to validate penguin dataset shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,3 +24,23 @@ jobs:
 
       - name: Run Python script
         run: uv run python main.py
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install uv
+          uv sync
+
+      - name: Run tests
+        run: uv run pytest test_main.py -v

--- a/main.py
+++ b/main.py
@@ -6,6 +6,6 @@ def load_penguin_data():
     df = pd.read_csv(url)
     return df.shape
 
-if _name_ == "_main_":
+if __name__ == "__main__":
     shape = load_penguin_data()
     print(f"Penguin dataset shape: {shape}")

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,6 @@
+from main import load_penguin_data
+
+def test_penguin_data_shape():
+    """Test that penguin dataset has expected shape"""
+    shape = load_penguin_data()
+    assert shape == (344, 7), f"Expected (344, 7), got {shape}"


### PR DESCRIPTION
1. Added `test_main.py` to verify the shape of the penguin dataset (344 rows × 7 columns).
2.Updated `.github/workflows/ci.yml` to include a test job using pytest.
3.Confirmed that both build and test jobs pass locally using `uv run`.

Requesting to merge changes to `main` only after CI checks pass 
